### PR TITLE
Lua 5.2 and Visual C++

### DIFF
--- a/lyaml.c
+++ b/lyaml.c
@@ -44,6 +44,12 @@
 #define luaL_openlib(L, libname, l, nup) luaL_newlib(L, l)
 #endif
 
+/* fix compilation with Visual C++ /TC */
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#define inline __inline
+#endif
+
 /* configurable flags */
 static char Dump_Auto_Array = 1;
 static char Dump_Error_on_Unsupported = 0;

--- a/lyaml.c
+++ b/lyaml.c
@@ -36,6 +36,14 @@
 #include "yaml.h"
 #include "b64.h"
 
+/* fix compilation for Lua 5.2 */
+#if LUA_VERSION_NUM==502
+#define lua_strlen lua_rawlen
+#define luaL_getn lua_rawlen
+#define luaL_reg luaL_Reg
+#define luaL_openlib(L, libname, l, nup) luaL_newlib(L, l)
+#endif
+
 /* configurable flags */
 static char Dump_Auto_Array = 1;
 static char Dump_Error_on_Unsupported = 0;


### PR DESCRIPTION
I fixed compilation (in a preprocessorish way) for Lua 5.2, and on Visual C++ (which lacks inline in C mode and snprintf).

Feel free to grab either changeset.
